### PR TITLE
Make ENG_SIG work optional

### DIFF
--- a/PRYMETIME/PRYMETIME.sh
+++ b/PRYMETIME/PRYMETIME.sh
@@ -114,6 +114,9 @@ $EXECDIR/split.sh "$OUTDIR"
 $EXECDIR/unicycler.sh "$IN_FASTQ_NANOPORE" "$IN_FASTQ_ILLUMINA_1" \
     "$IN_FASTQ_ILLUMINA_2" "$OUTDIR"
     
-$EXECDIR/eng_sig_blast.sh "$OUTDIR" "$ENG_SIG"
+# if ENG_SIG argument was provided, do some more work
+if [ ! -z ${ENG_SIG+x} ]; then
+    $EXECDIR/eng_sig_blast.sh "$OUTDIR" "$ENG_SIG"
 
-$EXECDIR/eng_sig_figure.sh "$OUTDIR"
+    $EXECDIR/eng_sig_figure.sh "$OUTDIR"
+fi


### PR DESCRIPTION
If ENG_SIG is provided, do the related work. Otherwise skip it.