### PR TITLE
Resolving Python compatibility issues in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,12 @@ RUN pip3 install idna
 # Install Cython
 RUN pip3 install --upgrade cython
 
+# Setuptools-scm requires separate pre-install due to Python version compatibility
+RUN pip3 install setuptools-scm==6.4.2
+
+# Later versions of protobuf drop Python 3.6
+RUN pip3 install protobuf==3.19.4
+
 # Medaka only runs on python 3.5 and python 3.6 as of January,
 # 2020. This ties us to Ubuntu 18.04.
 RUN pip3 install medaka==0.12.0


### PR DESCRIPTION
This commit addresses Python version incompatibility between Medaka and Protobuf. The latest Protobuf release requires Python 3.7 but Medaka only runs on Python 3.6.9. This commit modifies the Dockerfile to address the issue.

**Protobuf error**
```
protobuf requires Python '>=3.7' but the running Python is 3.6.9
The command '/bin/sh -c pip3 install medaka==0.12.0' returned a non-zero code: 1
```

**SyntaxError**
```
File "/tmp/pip-build-mef35aut/pyfaidx/.eggs/setuptools_scm-7.0.2-py3.6.egg/setuptools_scm/__init__.py", line 5
from __future__ import annotations
        ^
    SyntaxError: future feature annotations is not defined
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-mef35aut/pyfaidx/
The command '/bin/sh -c pip3 install medaka==0.12.0' returned a non-zero code: 1
```